### PR TITLE
Remove num dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,3 @@ path = "src/lib.rs"
 [dependencies]
 
 libc = "*"
-num = "*"


### PR DESCRIPTION
Get rid of the dependency on the num crate, which was only being used for casting `size_of::<sockaddr>()` to usize (and it wasn't being used consistently anyway).
